### PR TITLE
include string.h in pixma_unpack.c

### DIFF
--- a/pixma_unpack.c
+++ b/pixma_unpack.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 static unsigned char sig[] = 
 {


### PR DESCRIPTION
fixes this error (on macOS 15.4, clang 17.0.0)
pixma_unpack.c:79:26: error: call to undeclared library function 'memchr' with type 'void *(const void *, int, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]