### PR TITLE
update format string to use longs instead of unsigned ints

### DIFF
--- a/pixma_unpack.c
+++ b/pixma_unpack.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
 		fread(&end, 4, 1, fp);
 		fread(&start, 4, 1, fp);
 		size=end-start;
-		printf ("Data offset: %08X\nStart address %08X\nEnd address %08X\nSize: %d bytes\n\n", offset, start, end, size);
+		printf ("Data offset: %08lX\nStart address %08X\nEnd address %08X\nSize: %ld bytes\n\n", offset, start, end, size);
 		offset &= 0xFFFFFF;
 	}
 


### PR DESCRIPTION
fixes:
pixma_unpack.c:123:90: warning: format specifies type 'unsigned int' but the argument has type 'long' [-Wformat]

pixma_unpack.c:123:110: warning: format specifies type 'int' but the argument has type 'long' [-Wformat]